### PR TITLE
Update README.md - worker URL to package assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://github.com/peerlibrary/meteor-pdf.js
 ```js
 /* In your Template.xxx.rendered */
 // Set worker URL to package assets
-PDFJS.workerSrc = '/packages/pdfjs/build/pdf.worker.js';
+PDFJS.workerSrc = '/packages/pascoual_pdfjs/build/pdf.worker.js';
 // Create PDF
 PDFJS.getDocument(url).then(function getPdfHelloWorld(pdf) {
 	// Fetch the first page


### PR DESCRIPTION
Hi,
the correct URL for the PDFJS.workerSrc is '/packages/pascoual_pdfjs/build/pdf.worker.js';